### PR TITLE
FEAT: 검색창 화면, 최근 검색어 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("androidx.compose.material3:material3:1.1.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    implementation("com.google.android.engage:engage-core:1.2.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/app/src/main/java/com/example/newtineproject/domain/model/search/RealtimeArticle.kt
+++ b/app/src/main/java/com/example/newtineproject/domain/model/search/RealtimeArticle.kt
@@ -1,0 +1,10 @@
+package com.example.newtineproject.domain.model.search
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class RealtimeArticle (
+    var number: Int,
+    var icon: ImageVector,
+    var title: String,
+    //
+)

--- a/app/src/main/java/com/example/newtineproject/domain/model/search/RecentViewedArticle.kt
+++ b/app/src/main/java/com/example/newtineproject/domain/model/search/RecentViewedArticle.kt
@@ -1,0 +1,7 @@
+package com.example.newtineproject.domain.model.search
+
+data class RecentViewedArticle (
+    var thumbnail: Int,
+    var title: String,
+    var publication: String
+)

--- a/app/src/main/java/com/example/newtineproject/domain/model/search/Recommendation.kt
+++ b/app/src/main/java/com/example/newtineproject/domain/model/search/Recommendation.kt
@@ -1,0 +1,6 @@
+package com.example.newtineproject.domain.model.search
+
+data class Recommendation (
+    var title: String,
+    var publication: String
+)

--- a/app/src/main/java/com/example/newtineproject/graphs/navigation_bar_items/HomeNavGraph.kt
+++ b/app/src/main/java/com/example/newtineproject/graphs/navigation_bar_items/HomeNavGraph.kt
@@ -10,6 +10,7 @@ import com.example.newtineproject.ui.screens.home.HomeScreen
 import com.example.newtineproject.ui.screens.home.article.ArticleScreen
 import com.example.newtineproject.ui.screens.home.habitsetting.HabitSettingScreen
 import com.example.newtineproject.ui.screens.home.notification.NotificationScreen
+import com.example.newtineproject.ui.screens.home.search.SearchScreen
 
 fun NavGraphBuilder.homeNavGraph(
     navController: NavHostController,
@@ -37,7 +38,9 @@ fun NavGraphBuilder.homeNavGraph(
         composable(route = HomeDetailScreen.HabitSetting.route) {
             HabitSettingScreen(navController = navController)
         }
-
+        composable(route = HomeDetailScreen.Search.route){
+            SearchScreen(navController = navController)
+        }
     }
 }
 
@@ -46,4 +49,5 @@ sealed class HomeDetailScreen(val route: String) {
     data object Notification: HomeDetailScreen(route = "NOTIFICATION")
     data object Article: HomeDetailScreen(route = "ARTICLE")
     data object HabitSetting: HomeDetailScreen(route = "HABIT_SETTING")
+    data object Search: HomeDetailScreen(route = "SEARCH")
 }

--- a/app/src/main/java/com/example/newtineproject/ui/screens/home/components/HomeTopAppBar.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/home/components/HomeTopAppBar.kt
@@ -40,7 +40,7 @@ fun HomeTopAppBar(
         actions = {
             IconButton(
                 onClick = {
-
+                    navController.navigate(HomeDetailScreen.Search.route)
                 },
             ) {
                 Icon(

--- a/app/src/main/java/com/example/newtineproject/ui/screens/home/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/home/search/SearchScreen.kt
@@ -1,0 +1,291 @@
+package com.example.newtineproject.ui.screens.home.search
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.InputChipDefaults.inputChipBorder
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.newtineproject.R
+import com.example.newtineproject.domain.model.search.RealtimeArticle
+import com.example.newtineproject.domain.model.search.RecentViewedArticle
+import com.example.newtineproject.domain.model.search.Recommendation
+import com.example.newtineproject.ui.screens.home.search.components.RealtimeArticleItem
+import com.example.newtineproject.ui.screens.home.search.components.RecentViewedItem
+import com.example.newtineproject.ui.screens.home.search.components.RecommendedArticleItem
+import com.google.android.material.search.SearchBar
+
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun SearchScreen(navController: NavController) {
+    var text by remember { mutableStateOf("") }
+    var active by remember { mutableStateOf(false) }
+    var recentHistoryItems = remember {
+        mutableStateListOf("뉴스")
+    }
+    var selected by remember { mutableStateOf(false) }
+
+    Scaffold(
+
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = Color.White)
+        ) {
+
+
+            Spacer(modifier = Modifier.height(22.dp))
+            Text(
+                text = "최근 검색어",
+                style = LocalTextStyle.current.copy(
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                ),
+                modifier = Modifier
+                    .padding(start = 16.dp)
+            )
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.Start
+            ){
+                recentHistoryItems.forEach {text->
+                    InputChip(
+                        selected = selected,
+                        onClick = {
+                            /* go somewhere */
+                        },
+                        label = {
+                            Text(
+                                text = "$text",
+                                modifier = Modifier.padding(vertical = 4.dp),
+                                style = LocalTextStyle.current.copy(
+                                    color = Color.Gray,
+                                    fontWeight = FontWeight(400),
+                                    textAlign = TextAlign.Center
+                                )
+                            ) },
+                        shape = RoundedCornerShape(18.dp),
+                        border = inputChipBorder(
+                            borderColor = Color.LightGray,
+                            borderWidth = 1.dp
+                        ),
+                        colors = InputChipDefaults.inputChipColors(Color.White),
+                        trailingIcon = {
+                            Icon(
+                                //chip has to be removed once clicked
+                                imageVector = Icons.Default.Close,
+                                tint = Color.LightGray,
+                                contentDescription = "Close Chip",
+                                modifier = Modifier.size(InputChipDefaults.AvatarSize),
+                            )
+                        }
+                    )
+                }
+            }
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(11.dp)
+                    .background(color = Color(0xFFF3F4F6))
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "추천 뉴스",
+                style = LocalTextStyle.current.copy(
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                ),
+                modifier = Modifier
+                    .padding(start = 16.dp)
+            )
+            LazyColumn(
+                contentPadding = it,
+                modifier = Modifier
+                    .padding(horizontal = 23.dp)
+            ){
+                items(recommendationList){recommendation ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                    ){
+                        RecommendedArticleItem(
+                            recommendation = recommendation,
+                            onItemClick = {}
+                        )
+                    }
+
+                }
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "실시간 인기 뉴스",
+                style = LocalTextStyle.current.copy(
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                ),
+                modifier = Modifier
+                    .padding(start = 16.dp)
+            )
+            LazyColumn(
+                contentPadding = it,
+                modifier = Modifier
+                    .padding(horizontal = 23.dp)
+            ){
+                items(realtimeArticleList){ realtimeArticle ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                    ){
+                        RealtimeArticleItem(
+                            realtimeArticle = realtimeArticle,
+                            onItemClick = {}
+                        )
+                    }
+
+                }
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "최근 본 뉴스",
+                style = LocalTextStyle.current.copy(
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                ),
+                modifier = Modifier
+                    .padding(start = 16.dp)
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            LazyRow(
+                contentPadding = it,
+                modifier = Modifier
+                    .padding(horizontal = 15.dp)
+            ){
+                items(recentViewedList){ recentViewedArticle ->
+                    Row(
+                        modifier = Modifier
+                            .padding(horizontal = 10.dp)
+                    ){
+                        RecentViewedItem(
+                            recentViewedArticle = recentViewedArticle,
+                            onItemClick = {}
+                        )
+                    }
+
+                }
+            }
+        }
+    }
+}
+
+val recommendationList = listOf(
+    Recommendation(
+        title = "파업 일주일 앞…\"항공대란 막아라\"..",
+        publication = "한국일보"
+    ),
+    Recommendation(
+        title = "긴급대출·만기연장…금융업계, 수해 지원 ..",
+        publication = "연합뉴스"
+    ),
+    Recommendation(
+        title = "테슬라, 첫 전기 트럭 생산 소식에 개장 전 ..",
+        publication = "한국경제"
+    ),
+    Recommendation(
+        title = "\"해외 휴가 비행기 못 타나요?\"…아시아 ..",
+        publication = "연합뉴스TV"
+    )
+
+)
+
+val realtimeArticleList = listOf(
+    RealtimeArticle(
+        number = 1,
+        icon = Icons.Default.KeyboardArrowUp,
+        title = "상반기 K팝 수출액 최고치, 미국.."
+    ),
+    RealtimeArticle(
+        number = 2,
+        icon = Icons.Default.Add,
+        title = "하한가 사태, 주식 시장 불안 영향.."
+    ),
+    RealtimeArticle(
+        number = 3,
+        icon = Icons.Default.KeyboardArrowDown,
+        title = "영화 ‘엘리멘탈’ 관객 돌파 속도 .."
+    ),
+
+    )
+
+val recentViewedList = listOf(
+    RecentViewedArticle(
+        thumbnail = R.drawable.article10,
+        title = "한국 가계빚 증가 속도 세계 2위",
+        publication = "파이낸셜 뉴스"
+    ),
+    RecentViewedArticle(
+        thumbnail = R.drawable.article11,
+        title = "'극한 호우'에 여의도 94배 논밭 잠겼다 …",
+        publication = "매일경제"
+    ),
+    RecentViewedArticle(
+        thumbnail = R.drawable.article12,
+        title = "2023 국제해양영화제, 부산서 21일 개막",
+        publication = "중앙일보"
+    ),
+    RecentViewedArticle(
+        thumbnail = R.drawable.article13,
+        title = "한국 가계빚 증가 속도 세계 2위",
+        publication = "파이낸셜 뉴스"
+    ),
+
+
+    )

--- a/app/src/main/java/com/example/newtineproject/ui/screens/home/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/home/search/SearchScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.InputChipDefaults.inputChipBorder
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -53,11 +54,10 @@ import com.example.newtineproject.domain.model.search.Recommendation
 import com.example.newtineproject.ui.screens.home.search.components.RealtimeArticleItem
 import com.example.newtineproject.ui.screens.home.search.components.RecentViewedItem
 import com.example.newtineproject.ui.screens.home.search.components.RecommendedArticleItem
-import com.google.android.material.search.SearchBar
 
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun SearchScreen(navController: NavController) {
     var text by remember { mutableStateOf("") }
@@ -75,8 +75,68 @@ fun SearchScreen(navController: NavController) {
                 .fillMaxWidth()
                 .background(color = Color.White)
         ) {
+            //SearchBar
+            SearchBar(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp)
+                    .background(Color.White),
+                query = text,
+                onQueryChange = {
+                    text = it
+                },
+                onSearch = {
+                    recentHistoryItems.add(text)
+                    text = ""
+                    active = false
 
-
+                },
+                active = active,
+                onActiveChange = {
+                    active = it
+                },
+                placeholder = {
+                    Text(
+                        text = "Search news",
+                        style = LocalTextStyle.current.copy(
+                            color = Color(0xFF9CA3AF)
+                        )
+                    )
+                },
+                leadingIcon = {
+                    IconButton(
+                        onClick = {
+                            navController.popBackStack()
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Search news"
+                        )
+                    }
+                },
+                trailingIcon = {
+                    if (active) {
+                        Icon(
+                            modifier = Modifier.clickable {
+                                if (text.isNotEmpty()) {
+                                    text = ""
+                                } else {
+                                    active = false
+                                }
+                            },
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Close"
+                        )
+                    }
+                }
+            ) {
+                recentHistoryItems.forEach {
+                    Row(modifier = Modifier.padding(all = 14.dp)){
+                        Text(text = it)
+                    }
+                }
+            }
             Spacer(modifier = Modifier.height(22.dp))
             Text(
                 text = "최근 검색어",
@@ -95,6 +155,7 @@ fun SearchScreen(navController: NavController) {
             ){
                 recentHistoryItems.forEach {text->
                     InputChip(
+                        modifier = Modifier.padding(horizontal = 2.dp),
                         selected = selected,
                         onClick = {
                             /* go somewhere */

--- a/app/src/main/java/com/example/newtineproject/ui/screens/home/search/components/RealtimeArticleItem.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/home/search/components/RealtimeArticleItem.kt
@@ -1,0 +1,63 @@
+package com.example.newtineproject.ui.screens.home.search.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.newtineproject.domain.model.search.RealtimeArticle
+
+@Composable
+fun RealtimeArticleItem(
+    realtimeArticle: RealtimeArticle,
+    onItemClick: (RealtimeArticle) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onItemClick(realtimeArticle) }
+    ){
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ){
+            Text(
+                text = realtimeArticle.number.toString(),
+                style = LocalTextStyle.current.copy(
+                    fontSize = 14.sp,
+                    color = Color.Black
+                )
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Icon(
+                imageVector = realtimeArticle.icon,
+                tint = Color.Red,
+                contentDescription = null
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = realtimeArticle.title,
+                style = LocalTextStyle.current.copy(
+                    fontSize = 14.sp,
+                    color = Color.Black,
+                    fontWeight = FontWeight(400)
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/newtineproject/ui/screens/home/search/components/RecentViewedItem.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/home/search/components/RecentViewedItem.kt
@@ -1,0 +1,65 @@
+package com.example.newtineproject.ui.screens.home.search.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.newtineproject.domain.model.search.RecentViewedArticle
+
+@Composable
+fun RecentViewedItem(
+    recentViewedArticle: RecentViewedArticle,
+    onItemClick: (RecentViewedArticle) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .clickable{onItemClick(recentViewedArticle)}
+    ){
+        Spacer(modifier = Modifier.height(10.dp))
+        Image(
+            painter = painterResource(id = recentViewedArticle.thumbnail),
+            contentDescription = "thumbnail Image",
+            modifier = Modifier
+                .width(110.dp)
+                .height(75.dp)
+                .clip(RoundedCornerShape(4.dp)),
+            contentScale = ContentScale.FillBounds
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = recentViewedArticle.title,
+            modifier = Modifier
+                .width(110.dp),
+            style = LocalTextStyle.current.copy(
+                fontSize = 12.sp,
+                color = Color.Black,
+                fontWeight = FontWeight(400)
+            ),
+            lineHeight = 15.sp
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = recentViewedArticle.publication,
+            modifier = Modifier
+                .width(110.dp),
+            style = LocalTextStyle.current.copy(
+                fontSize = 10.sp,
+                color = Color.Gray
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/newtineproject/ui/screens/home/search/components/RecommendedArticleItem.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/home/search/components/RecommendedArticleItem.kt
@@ -1,0 +1,57 @@
+package com.example.newtineproject.ui.screens.home.search.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.newtineproject.domain.model.search.Recommendation
+
+@Composable
+fun RecommendedArticleItem(
+    recommendation: Recommendation,
+    onItemClick: (Recommendation) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {onItemClick(recommendation)}
+    ){
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = recommendation.title,
+                style = LocalTextStyle.current.copy(
+                    fontSize = 14.sp,
+                    color = Color.Black,
+                    fontWeight = FontWeight(400)
+                )
+            )
+
+            Text(
+                text = recommendation.publication,
+                style = LocalTextStyle.current.copy(
+                    fontSize = 11.sp,
+                    color = Color.Gray,
+                    fontWeight = FontWeight(400)
+                )
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/newtineproject/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/main/MainScreen.kt
@@ -54,6 +54,7 @@ import com.example.newtineproject.ui.screens.home.components.HomeTopAppBar
 import com.example.newtineproject.ui.theme.LightBlue
 import com.example.newtineproject.ui.theme.NavigationBarColor
 
+@OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MainScreen(navController: NavHostController = rememberNavController()) {

--- a/app/src/main/java/com/example/newtineproject/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/com/example/newtineproject/ui/screens/main/MainScreen.kt
@@ -54,7 +54,6 @@ import com.example.newtineproject.ui.screens.home.components.HomeTopAppBar
 import com.example.newtineproject.ui.theme.LightBlue
 import com.example.newtineproject.ui.theme.NavigationBarColor
 
-@OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MainScreen(navController: NavHostController = rememberNavController()) {


### PR DESCRIPTION
## Search screen

https://github.com/New-Tine/New-Tine-Android-Compose1/assets/113654733/7aed05c5-3b4f-4fcb-b153-1202b92caf85

## 추가적으로 해야할 것
- 최근검색어 input chip의 x아이콘 클릭 시 삭제되고, 바디 클릭 시 해당 검색결과로 가야함
- 실시간 인기 뉴스의 1,2,3 해당 아이콘 수정해야함
- bottom bar 적용해야함
- searchbar 클릭시 검색창에 나타나는 searchview 구현해야함